### PR TITLE
selected_key array not sorted

### DIFF
--- a/app/assets/javascripts/piggybak_variants/piggybak_variants.js
+++ b/app/assets/javascripts/piggybak_variants/piggybak_variants.js
@@ -16,7 +16,7 @@ var piggybak_variants = {
 				all_selected = false;	
 			}
 		});
-		var selected_key = selected.join('_');
+		var selected_key = selected.sort().join('_');
 		if(all_selected && variant_map[selected_key]) {
 			$('.variant_options form').show();
 			$('#sellable_id').val(variant_map[selected_key].id);


### PR DESCRIPTION
While testing I encountered a the variant map saying there wasn't a matching combo for a given variant combination that indeed existed.  Adding a sort on the selected_key array to align with the creation of the variant_map json object in the helper fixed the issue.
