### PR TITLE
all_selected now shows in any blank state

### DIFF
--- a/app/assets/javascripts/piggybak_variants/piggybak_variants.js
+++ b/app/assets/javascripts/piggybak_variants/piggybak_variants.js
@@ -29,8 +29,8 @@ function extractRadioButtonValues(){
 function extractDropdownValues(){     
   var all_selected = true;
   $('.variant_options select').each(function() { 
-      if ($(this).attr('value') == '') {
-        all_selected = false;
+      if (this.selectedIndex == 0) {
+          all_selected = false;
       }
   });
   var selected = new Array();


### PR DESCRIPTION
The previous version, was setting `all_selected` to be false if `$(this).attr('value') == ''`. However, ideally what we want is once the selected option's value is blank, we want to display the `span.all_selected` (which the current version doesn't do - but this change does). `""` and `null` and `blank` aren't all identical.

As a result, the current version was failing that 'blank state' test both on first load, and when the user goes back to the blank state after multiple options are selected. 

In this change, on the first page load, the message seen is `You must select a choice from each option`. That message is then seen whenever any required option is left blank, as opposed to just on the first page load. i.e. it now behaves like the user would expect it to behave.
