### PR TITLE
Added piggybak_variants.js to precompilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Finally, add `<%= variant_cart_form(@instance) %>` to your sellable item's show 
 
 OPTION:  `<%= variant_cart_form(@instance, :controls => 'dropdowns') %>` to render dropdowns instead of radio buttons.
 
+In your `config/environments/production.rb`, add the following line to allow pre-compilation of piggybak_variants.js:
+
+    config.assets.precompile += %w(piggybak_variants/piggybak_variants.js)
+
+So either add that line, or if you already have it enabled just add `piggybak_variants/piggybak_variants.js` to the array of values.
 
 TODO
 ========


### PR DESCRIPTION
When pushing to Heroku, if you don't specify the right filepath for piggybak_variants.js it will throw an error - because it isn't pre-compiled. This fixes that issue.
