### PR TITLE
Update piggybak_variants.js

### DIFF
--- a/app/assets/javascripts/piggybak_variants/piggybak_variants.js
+++ b/app/assets/javascripts/piggybak_variants/piggybak_variants.js
@@ -1,7 +1,7 @@
 var piggybak_variants = {
 	refreshControls : function(data) {
 		if(data.all_selected) { // if all selected
-			var selected_key = data.selected.sort().join('_');
+			var selected_key = data.selected.sort(function (a, b) { return a - b }).join('_');
 			if(variant_map[selected_key]) {
 				$('.variant_options form').show();
 				$('#sellable_id').val(variant_map[selected_key].id);


### PR DESCRIPTION
Bug fix with option_value IDs bigger than 9

To build the "selected_key" variable in JS file, sort() javascript method is used. Sort doesn't work properly with integers.

http://jsfiddle.net/Hgwky/
